### PR TITLE
ENH: make ticker read from deployments:

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,17 +25,7 @@ crossorigin=""></script>
 <h3> Deployments </h3>
 
 
-<header class="intro-header2" style="background-color:#6E7588;foreground-color:#FFFFFF">
-  <div class="container">
-     <div class="row">
-        <div>
-            <div class="subheading" style="padding: 6px 1em 0.2em 1em;color:#FFFFFF">
-                  To date, our gliders have traveled {% include totalkm.html %} km, and made {% include totalprofiles.html %} CTD, O2, and optics casts.
-            </div>
-        </div>
-      </div>
-   </div>
- </header>
+<p><iframe src="gliderdata/deployments/Totals.html" frameborder="0" width="95%" height="75"></iframe></p>
 
 C-PROOF glider deployments are under way! Check out our <a style="font-weight:bold" href='/deployments/'>Deployments Page</a> to see the list of glider deployments and access data, and check out our <a style="font-weight:bold" href='/platforms/'>Platforms Page</a> for information about the Argo floats:
 


### PR DESCRIPTION
This reads the ticker from gliderdata/deployments with is a more flexible place to read it from.  